### PR TITLE
fix: add @types/node to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,14 +8,29 @@
     "type": "git",
     "url": "https://github.com/nexus-substrate/memory-bench.git"
   },
-  "keywords": ["memory", "benchmark", "mcp", "nexus-agents", "e2e-test"],
-  "engines": { "node": ">=22" },
+  "keywords": [
+    "memory",
+    "benchmark",
+    "mcp",
+    "nexus-agents",
+    "e2e-test"
+  ],
+  "engines": {
+    "node": ">=22"
+  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "import": "./dist/index.js", "types": "./dist/index.d.ts" }
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
   },
-  "files": ["dist", "src", "README.md"],
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run",
@@ -25,7 +40,8 @@
   "devDependencies": {
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "@types/node": "^22.0.0"
   },
   "dependencies": {
     "zod": "^3.24.0"


### PR DESCRIPTION
## Problem

`pnpm typecheck` and `pnpm build` fail on a clean install:

```
src/live-caller.ts(14,10): error TS2580: Cannot find name 'process'.
src/run-live.ts(15,5): error TS2580: Cannot find name 'process'.
```

`@types/node` appears in pnpm-lock.yaml only as an optional peer dependency of tsx/vitest; it is not installed in node_modules and not listed in `devDependencies`.

Fixes #8

## Fix

Add `@types/node: "^22.0.0"` to `devDependencies` (matching `engines.node >=22`).
